### PR TITLE
Next major version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - `Innmind\OperatingSystem\Ports\Unix::of()` is now declared `internal`
 - `Innmind\OperatingSystem\Remote\Generic::of()` is now declared `internal`
 - `Innmind\OperatingSystem\Ports\Sockets::of()` is now declared `internal`
+- Requires `innmind/file-watch:~4.0`
 
 ## 4.2.0 - 2023-12-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
 
 - `Innmind\OperatingSystem\Remote::socket()` returned socket is now wrapped in a `Innmind\IO\Sockets\Client`
 - `Innmind\OperatingSystem\Sockets::connectTo()` returned socket is now wrapped in a `Innmind\IO\Sockets\Client`
+- `Innmind\OperatingSystem\Sockets::open()` returned socket is now wrapped in a `Innmind\IO\Sockets\Server`
+- `Innmind\OperatingSystem\Sockets::takeOver()` returned socket is now wrapped in a `Innmind\IO\Sockets\Server`
+- `Innmind\OperatingSystem\Ports::open()` returned socket is now wrapped in a `Innmind\IO\Sockets\Server`
 
 ## 4.2.0 - 2023-12-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+
+- `Innmind\OperatingSystem\Filesystem::temporary()`
+
 ## 4.2.0 - 2023-12-14
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@
 
 - `Innmind\OperatingSystem\Filesystem::temporary()`
 
+### Changed
+
+- `Innmind\OperatingSystem\Remote::socket()` returned socket is now wrapped in a `Innmind\IO\Sockets\Client`
+- `Innmind\OperatingSystem\Sockets::connectTo()` returned socket is now wrapped in a `Innmind\IO\Sockets\Client`
+
 ## 4.2.0 - 2023-12-14
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@
 - `Innmind\OperatingSystem\Sockets::open()` returned socket is now wrapped in a `Innmind\IO\Sockets\Server`
 - `Innmind\OperatingSystem\Sockets::takeOver()` returned socket is now wrapped in a `Innmind\IO\Sockets\Server`
 - `Innmind\OperatingSystem\Ports::open()` returned socket is now wrapped in a `Innmind\IO\Sockets\Server`
+- `Innmind\OperatingSystem\CurrentProcess\Generic::of()` is now declared `internal`
+- `Innmind\OperatingSystem\Filesystem\Generic::of()` is now declared `internal`
+- `Innmind\OperatingSystem\Ports\Unix::of()` is now declared `internal`
+- `Innmind\OperatingSystem\Remote\Generic::of()` is now declared `internal`
+- `Innmind\OperatingSystem\Ports\Sockets::of()` is now declared `internal`
 
 ## 4.2.0 - 2023-12-14
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ $server = $os
         Port::of(1337),
     )
     ->match(
-        static fn($server) => $server,
+        static fn($server) => $server->unwrap(),
         static fn() => throw new \RuntimeException('Cannot open the socket'),
     );
 ```
@@ -84,7 +84,7 @@ $server = $os
 use Innmind\Socket\Address\Unix;
 
 $server = $os->sockets()->open(Unix::of('/tmp/foo.sock'))->match(
-    static fn($server) => $server,
+    static fn($server) => $server->unwrap(),
     static fn() => throw new \RuntimeException('Cannot open the socket'),
 );
 ```
@@ -95,7 +95,10 @@ $server = $os->sockets()->open(Unix::of('/tmp/foo.sock'))->match(
 # process B
 use Innmind\Socket\Address\Unix;
 
-$client = $os->sockets()->connectTo(Unix::of('/tmp/foo.sock'));
+$client = $os->sockets()->connectTo(Unix::of('/tmp/foo.sock'))->match(
+    static fn($client) => $client->unwrap(),
+    static fn() => throw new \RuntimeException('Cannot connect to the socket'),
+);
 ```
 
 `$client` is an instance of `Innmind\Socket\Client`.

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "innmind/file-watch": "~3.1",
         "innmind/stream": "~4.0",
         "formal/access-layer": "^2.0",
-        "innmind/io": "~2.2"
+        "innmind/io": "~2.7"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "innmind/http-transport": "~7.2",
         "innmind/time-warp": "~3.0",
         "innmind/signals": "~3.0",
-        "innmind/file-watch": "~3.1",
+        "innmind/file-watch": "~4.0",
         "innmind/stream": "~4.0",
         "formal/access-layer": "^2.0",
         "innmind/io": "~2.7"

--- a/documentation/use_cases/filesystem.md
+++ b/documentation/use_cases/filesystem.md
@@ -112,24 +112,23 @@ It is a great way to forget about where the tmp folder is located and simply foc
 A pattern we don't see much in PHP is an infinite loop to react to an event to perform another task. Here we can build such pattern by watching for changes in a file or a directory.
 
 ```php
-use Innmind\FileWatch\Stop;
-use Innmind\Immutable\Either;
+use Innmind\FileWatch\Continuation;
 
 $runTests = $os->filesystem()->watch(Path::of('/path/to/project/src/'));
 
-$count = $runTests(0, function(int $count) use ($os): Either {
+$count = $runTests(0, function(int $count, Continuation $continuation) use ($os): Continuation {
     if ($count === 42) {
-        return Either::left(Stop::of($count));
+        return $continuation->stop($count);
     }
 
     $os->control()->processes()->execute($phpunitCommand);
 
-    return Either::right(++$count);
+    return $continuation->continue(++$count);
 });
 ```
 
-Here it will run phpunit tests every time the `src/` folder changes. Concrete examples of this pattern can be found in [`innmind/lab-station`](https://github.com/Innmind/LabStation/blob/develop/src/Agent/WatchSources.php#L38) to run a suite of tools when sources change or in [`halsey/journal`](https://github.com/halsey-php/journal/blob/develop/src/Command/Preview.php#L58) to rebuild the website when the markdown files change.
+Here it will run phpunit tests every time the `src/` folder changes. Concrete examples of this pattern can be found in [`innmind/lab-station`](https://github.com/Innmind/LabStation/blob/develop/src/Agent/WatchSources.php#L38) to run a suite of tools when sources change.
 
-This operation is a bit like an `array_reduce` as you can keep a state record between each calls of the callable via the first argument (here `0`, but it can be anything) and the argument of your callable will be the previous value returned by `Either::right()`.
+This operation is a bit like an `array_reduce` as you can keep a state record between each calls of the callable via the first argument (here `0`, but it can be anything) and the argument of your callable will be the previous value returned by `$continuation->continue()`.
 
-**Important**: since there is not builtin way to watch for changes in a directory it checks the directory every second, so use it with care. Watching an individual file is a bit safer as it uses the `tail` command so there is no `sleep()` used.
+**Important**: since there is no builtin way to watch for changes in a directory it checks the directory every second, so use it with care. Watching an individual file is a bit safer as it uses the `tail` command so there is no `sleep()` used.

--- a/documentation/use_cases/signals.md
+++ b/documentation/use_cases/signals.md
@@ -2,7 +2,7 @@
 
 Any process can receive [signals](https://en.wikipedia.org/wiki/Signal_(IPC)) either through user interaction (in a terminal), from another process or via the `kill` command. PHP processes can handle them and perform actions to safely free resources or prevent the process from being terminated.
 
-Examples below only use one listener per signal but you can add as many as you want (which is complicated when dealing manually with PHP builtin functions).
+Examples below only use one listener per signal but you can add as many as you wish (which is complicated when dealing manually with PHP builtin functions).
 
 ## Free resources before stopping
 
@@ -10,33 +10,44 @@ This is a reuse of the [socket example](socket.md).
 
 ```php
 use Innmind\Url\Url;
+use Innmind\IO\Readable\Frame;
 use Innmind\Socket\Internet\Transport;
 use Innmind\TimeContinuum\Earth\ElapsedPeriod;
 use Innmind\Signals\Signal;
+use Innmind\Immutable\{
+    Sequence,
+    Str,
+};
 
 $client = $os->remote()->socket(Transport::tcp(), Ur::of('tcp://127.0.0.1:8080')->authority())->match(
     static fn($client) => $client,
     static fn() => throw new \RuntimeException('Unable to connect to the server'),
 );
 $watch = $os->sockets()->watch(new ElapsedPeriod(1000))->forRead($client);
-$continue = true;
-$os->process()->signals()->listen(Signal::terminate, function() use (&$continue, $client) {
-    $continue = false;
-    $client->close();
+$signaled = true;
+$os->process()->signals()->listen(Signal::terminate, function() use (&$signaled) {
+    $signaled = false;
 });
 
-do {
-    $ready = $watch()
-        ->flatMap(static fn($ready) => $ready->toRead()->find(static fn($ready) => $ready === $client))
-        ->match(
-            static fn() => true,
-            static fn() => false,
-        );
-} while ($continue && !$ready);
+$receivedData = $client
+    ->timeoutAfter(ElapsedPeriod::of(1_000))
+    // it sends this every second to keep the connection alive
+    ->heartbeatWith(static fn() => Sequence::of(Str::of('foo')))
+    ->abortWhen(function() use (&$signaled) {
+        return $signaled;
+    })
+    ->frames(Frame\Chunk::of(1))
+    ->one()
+    ->match(
+        static fn() => true,
+        static fn() => false,
+    );
 
-if (!$client->closed()) {
+if ($receivedData) {
     echo 'Server has responded'.
 }
+
+$client->unwrap()->close();
 ```
 
 When the process receive the `SIGTERM` signal it will be paused then the anonymous function will be called and the process will then be resumed.

--- a/src/Config.php
+++ b/src/Config.php
@@ -74,7 +74,10 @@ final class Config
                 default => $streams->watch()->timeoutAfter($timeout),
             }),
             new Halt\Usleep,
-            EnvironmentPath::of(\getenv('PATH') ?: ''),
+            EnvironmentPath::of(match ($path = \getenv('PATH')) {
+                false => '',
+                default => $path,
+            }),
             $maxHttpConcurrency,
             $httpHeartbeat,
             false,

--- a/src/CurrentProcess/Generic.php
+++ b/src/CurrentProcess/Generic.php
@@ -20,6 +20,9 @@ final class Generic implements CurrentProcess
         $this->halt = $halt;
     }
 
+    /**
+     * @internal
+     */
     public static function of(Halt $halt): self
     {
         return new self($halt);

--- a/src/CurrentProcess/Generic.php
+++ b/src/CurrentProcess/Generic.php
@@ -9,11 +9,6 @@ use Innmind\Server\Status\Server\Memory\Bytes;
 use Innmind\TimeContinuum\Period;
 use Innmind\TimeWarp\Halt;
 use Innmind\Signals\Handler;
-use Innmind\Immutable\{
-    Set,
-    Either,
-    SideEffect,
-};
 
 final class Generic implements CurrentProcess
 {

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -3,11 +3,6 @@ declare(strict_types = 1);
 
 namespace Innmind\OperatingSystem;
 
-use Innmind\TimeContinuum\{
-    Clock,
-    Earth,
-};
-
 final class Factory
 {
     public static function build(Config $config = null): OperatingSystem

--- a/src/Filesystem.php
+++ b/src/Filesystem.php
@@ -3,10 +3,17 @@ declare(strict_types = 1);
 
 namespace Innmind\OperatingSystem;
 
-use Innmind\Filesystem\Adapter;
+use Innmind\Filesystem\{
+    Adapter,
+    File\Content,
+};
 use Innmind\Url\Path;
 use Innmind\FileWatch\Ping;
-use Innmind\Immutable\Maybe;
+use Innmind\Immutable\{
+    Maybe,
+    Str,
+    Sequence,
+};
 
 interface Filesystem
 {
@@ -18,4 +25,18 @@ interface Filesystem
      */
     public function require(Path $path): Maybe;
     public function watch(Path $path): Ping;
+
+    /**
+     * This method is to be used to generate a temporary file content even if it
+     * doesn't fit in memory.
+     *
+     * Usually the sequence of chunks comes from reading a socket meaning it
+     * can't be read twice. By using this temporary file content you can read it
+     * multiple times.
+     *
+     * @param Sequence<Maybe<Str>> $chunks
+     *
+     * @return Maybe<Content>
+     */
+    public function temporary(Sequence $chunks): Maybe;
 }

--- a/src/Filesystem/Generic.php
+++ b/src/Filesystem/Generic.php
@@ -41,6 +41,9 @@ final class Generic implements Filesystem
         $this->mounted = new \WeakMap;
     }
 
+    /**
+     * @internal
+     */
     public static function of(Processes $processes, Config $config): self
     {
         return new self($processes, $config);

--- a/src/Filesystem/Logger.php
+++ b/src/Filesystem/Logger.php
@@ -4,10 +4,16 @@ declare(strict_types = 1);
 namespace Innmind\OperatingSystem\Filesystem;
 
 use Innmind\OperatingSystem\Filesystem;
-use Innmind\Filesystem\Adapter;
+use Innmind\Filesystem\{
+    Adapter,
+    File\Content,
+};
 use Innmind\Url\Path;
 use Innmind\FileWatch\Ping;
-use Innmind\Immutable\Maybe;
+use Innmind\Immutable\{
+    Maybe,
+    Sequence,
+};
 use Psr\Log\LoggerInterface;
 
 final class Logger implements Filesystem
@@ -72,5 +78,17 @@ final class Logger implements Filesystem
             $path,
             $this->logger,
         );
+    }
+
+    public function temporary(Sequence $chunks): Maybe
+    {
+        return $this
+            ->filesystem
+            ->temporary($chunks)
+            ->map(function(Content $content) {
+                $this->logger->debug('Temporary file created');
+
+                return $content;
+            });
     }
 }

--- a/src/OperatingSystem/Unix.php
+++ b/src/OperatingSystem/Unix.php
@@ -81,7 +81,7 @@ final class Unix implements OperatingSystem
 
     public function ports(): Ports
     {
-        return $this->ports ??= Ports\Unix::of();
+        return $this->ports ??= Ports\Unix::of($this->config);
     }
 
     public function sockets(): Sockets

--- a/src/Ports.php
+++ b/src/Ports.php
@@ -4,10 +4,8 @@ declare(strict_types = 1);
 namespace Innmind\OperatingSystem;
 
 use Innmind\Url\Authority\Port;
-use Innmind\Socket\{
-    Internet\Transport,
-    Server,
-};
+use Innmind\IO\Sockets\Server;
+use Innmind\Socket\Internet\Transport;
 use Innmind\IP\IP;
 use Innmind\Immutable\Maybe;
 

--- a/src/Ports/Logger.php
+++ b/src/Ports/Logger.php
@@ -5,10 +5,7 @@ namespace Innmind\OperatingSystem\Ports;
 
 use Innmind\OperatingSystem\Ports;
 use Innmind\Url\Authority\Port;
-use Innmind\Socket\{
-    Internet\Transport,
-    Server,
-};
+use Innmind\Socket\Internet\Transport;
 use Innmind\IP\IP;
 use Innmind\Immutable\Maybe;
 use Psr\Log\LoggerInterface;

--- a/src/Ports/Unix.php
+++ b/src/Ports/Unix.php
@@ -25,6 +25,9 @@ final class Unix implements Ports
         $this->config = $config;
     }
 
+    /**
+     * @internal
+     */
     public static function of(Config $config): self
     {
         return new self($config);

--- a/src/Ports/Unix.php
+++ b/src/Ports/Unix.php
@@ -3,29 +3,38 @@ declare(strict_types = 1);
 
 namespace Innmind\OperatingSystem\Ports;
 
-use Innmind\OperatingSystem\Ports;
+use Innmind\OperatingSystem\{
+    Ports,
+    Config,
+};
 use Innmind\Url\Authority\Port;
+use Innmind\IO\Sockets\Server;
 use Innmind\Socket\{
     Internet\Transport,
-    Server,
+    Server\Internet,
 };
 use Innmind\IP\IP;
 use Innmind\Immutable\Maybe;
 
 final class Unix implements Ports
 {
-    private function __construct()
+    private Config $config;
+
+    private function __construct(Config $config)
     {
+        $this->config = $config;
     }
 
-    public static function of(): self
+    public static function of(Config $config): self
     {
-        return new self;
+        return new self($config);
     }
 
     public function open(Transport $transport, IP $ip, Port $port): Maybe
     {
         /** @var Maybe<Server> */
-        return Server\Internet::of($transport, $ip, $port);
+        return Internet::of($transport, $ip, $port)->map(
+            $this->config->io()->sockets()->servers()->wrap(...),
+        );
     }
 }

--- a/src/Remote.php
+++ b/src/Remote.php
@@ -4,10 +4,8 @@ declare(strict_types = 1);
 namespace Innmind\OperatingSystem;
 
 use Innmind\Server\Control\Server;
-use Innmind\Socket\{
-    Internet\Transport,
-    Client,
-};
+use Innmind\Socket\Internet\Transport;
+use Innmind\IO\Sockets\Client;
 use Innmind\Url\{
     Url,
     Authority,

--- a/src/Remote/Generic.php
+++ b/src/Remote/Generic.php
@@ -39,6 +39,9 @@ final class Generic implements Remote
         $this->config = $config;
     }
 
+    /**
+     * @internal
+     */
     public static function of(Server $server, Config $config): self
     {
         return new self($server, $config);

--- a/src/Remote/Generic.php
+++ b/src/Remote/Generic.php
@@ -62,8 +62,9 @@ final class Generic implements Remote
 
     public function socket(Transport $transport, Authority $authority): Maybe
     {
-        /** @var Maybe<Client> */
-        return Client\Internet::of($transport, $authority);
+        return Client\Internet::of($transport, $authority)->map(
+            $this->config->io()->sockets()->clients()->wrap(...),
+        );
     }
 
     public function http(): HttpTransport

--- a/src/Remote/Logger.php
+++ b/src/Remote/Logger.php
@@ -5,10 +5,7 @@ namespace Innmind\OperatingSystem\Remote;
 
 use Innmind\OperatingSystem\Remote;
 use Innmind\Server\Control;
-use Innmind\Socket\{
-    Internet\Transport,
-    Client,
-};
+use Innmind\Socket\Internet\Transport;
 use Innmind\Url\{
     Url,
     Authority,

--- a/src/Remote/Resilient.php
+++ b/src/Remote/Resilient.php
@@ -8,10 +8,7 @@ use Innmind\OperatingSystem\{
     CurrentProcess,
 };
 use Innmind\Server\Control\Server;
-use Innmind\Socket\{
-    Internet\Transport,
-    Client,
-};
+use Innmind\Socket\Internet\Transport;
 use Innmind\Url\{
     Url,
     Authority,

--- a/src/Sockets.php
+++ b/src/Sockets.php
@@ -6,9 +6,9 @@ namespace Innmind\OperatingSystem;
 use Innmind\Socket\{
     Address\Unix,
     Server,
-    Client,
 };
 use Innmind\TimeContinuum\ElapsedPeriod;
+use Innmind\IO\Sockets\Client;
 use Innmind\Stream\Watch;
 use Innmind\Immutable\Maybe;
 

--- a/src/Sockets.php
+++ b/src/Sockets.php
@@ -3,12 +3,12 @@ declare(strict_types = 1);
 
 namespace Innmind\OperatingSystem;
 
-use Innmind\Socket\{
-    Address\Unix,
+use Innmind\IO\Sockets\{
+    Client,
     Server,
 };
+use Innmind\Socket\Address\Unix;
 use Innmind\TimeContinuum\ElapsedPeriod;
-use Innmind\IO\Sockets\Client;
 use Innmind\Stream\Watch;
 use Innmind\Immutable\Maybe;
 

--- a/src/Sockets/Logger.php
+++ b/src/Sockets/Logger.php
@@ -4,11 +4,7 @@ declare(strict_types = 1);
 namespace Innmind\OperatingSystem\Sockets;
 
 use Innmind\OperatingSystem\Sockets;
-use Innmind\Socket\{
-    Address\Unix as Address,
-    Server,
-    Client,
-};
+use Innmind\Socket\Address\Unix as Address;
 use Innmind\TimeContinuum\ElapsedPeriod;
 use Innmind\Stream\Watch;
 use Innmind\Immutable\Maybe;

--- a/src/Sockets/Unix.php
+++ b/src/Sockets/Unix.php
@@ -42,7 +42,9 @@ final class Unix implements Sockets
 
     public function connectTo(Address $address): Maybe
     {
-        return Client\Unix::of($address);
+        return Client\Unix::of($address)->map(
+            $this->config->io()->sockets()->clients()->wrap(...),
+        );
     }
 
     public function watch(ElapsedPeriod $timeout = null): Watch

--- a/src/Sockets/Unix.php
+++ b/src/Sockets/Unix.php
@@ -25,6 +25,9 @@ final class Unix implements Sockets
         $this->config = $config;
     }
 
+    /**
+     * @internal
+     */
     public static function of(Config $config): self
     {
         return new self($config);

--- a/src/Sockets/Unix.php
+++ b/src/Sockets/Unix.php
@@ -32,12 +32,16 @@ final class Unix implements Sockets
 
     public function open(Address $address): Maybe
     {
-        return Server\Unix::of($address);
+        return Server\Unix::of($address)->map(
+            $this->config->io()->sockets()->servers()->wrap(...),
+        );
     }
 
     public function takeOver(Address $address): Maybe
     {
-        return Server\Unix::recoverable($address);
+        return Server\Unix::recoverable($address)->map(
+            $this->config->io()->sockets()->servers()->wrap(...),
+        );
     }
 
     public function connectTo(Address $address): Maybe

--- a/tests/OperatingSystem/LoggerTest.php
+++ b/tests/OperatingSystem/LoggerTest.php
@@ -18,15 +18,9 @@ use Innmind\Server\Status;
 use Innmind\Server\Control;
 use Psr\Log\LoggerInterface;
 use PHPUnit\Framework\TestCase;
-use Innmind\BlackBox\{
-    PHPUnit\BlackBox,
-    Set,
-};
 
 class LoggerTest extends TestCase
 {
-    use BlackBox;
-
     private OperatingSystem $os;
     private OperatingSystem $underlying;
 

--- a/tests/Ports/UnixTest.php
+++ b/tests/Ports/UnixTest.php
@@ -6,6 +6,7 @@ namespace Tests\Innmind\OperatingSystem\Ports;
 use Innmind\OperatingSystem\{
     Ports\Unix,
     Ports,
+    Config,
 };
 use Innmind\Socket\{
     Internet\Transport,
@@ -19,19 +20,19 @@ class UnixTest extends TestCase
 {
     public function testInterface()
     {
-        $this->assertInstanceOf(Ports::class, Unix::of());
+        $this->assertInstanceOf(Ports::class, Unix::of(Config::of()));
     }
 
     public function testOpen()
     {
-        $ports = Unix::of();
+        $ports = Unix::of(Config::of());
 
         $socket = $ports->open(
             Transport::tlsv12(),
             IPv4::localhost(),
             Port::of(1234),
         )->match(
-            static fn($server) => $server,
+            static fn($server) => $server->unwrap(),
             static fn() => null,
         );
 

--- a/tests/Remote/GenericTest.php
+++ b/tests/Remote/GenericTest.php
@@ -102,7 +102,7 @@ class GenericTest extends TestCase
         );
 
         $socket = $remote->socket(Transport::tcp(), Url::of('tcp://127.0.0.1:1234')->authority())->match(
-            static fn($client) => $client,
+            static fn($client) => $client->unwrap(),
             static fn() => null,
         );
 

--- a/tests/Sockets/UnixTest.php
+++ b/tests/Sockets/UnixTest.php
@@ -29,7 +29,7 @@ class UnixTest extends TestCase
         $sockets = Unix::of(Config::of());
 
         $socket = $sockets->open(Address::of('/tmp/foo'))->match(
-            static fn($server) => $server,
+            static fn($server) => $server->unwrap(),
             static fn() => null,
         );
 
@@ -48,11 +48,11 @@ class UnixTest extends TestCase
         $sockets = Unix::of(Config::of());
 
         $socket = $sockets->open(Address::of('/tmp/foo'))->match(
-            static fn($server) => $server,
+            static fn($server) => $server->unwrap(),
             static fn() => null,
         );
         $socket2 = $sockets->takeOver(Address::of('/tmp/foo'))->match(
-            static fn($server) => $server,
+            static fn($server) => $server->unwrap(),
             static fn() => null,
         );
 
@@ -66,7 +66,7 @@ class UnixTest extends TestCase
         $sockets = Unix::of(Config::of());
 
         $server = $sockets->open(Address::of('/tmp/foo'))->match(
-            static fn($server) => $server,
+            static fn($server) => $server->unwrap(),
             static fn() => null,
         );
         $client = $sockets->connectTo(Address::of('/tmp/foo'))->match(

--- a/tests/Sockets/UnixTest.php
+++ b/tests/Sockets/UnixTest.php
@@ -70,7 +70,7 @@ class UnixTest extends TestCase
             static fn() => null,
         );
         $client = $sockets->connectTo(Address::of('/tmp/foo'))->match(
-            static fn($client) => $client,
+            static fn($client) => $client->unwrap(),
             static fn() => null,
         );
 


### PR DESCRIPTION
## Why

This PR is here to add/modify this package in order for the [next major version of `innmind/amqp`](https://github.com/Innmind/AMQP/pull/3) to only rely on this abstraction and no longer access the underlying `innmind/streams` or `innmind/io`.

This will allow `innmind/amqp` to be used safely in an asynchronous context inside `innmind/mantle`.

## What

- Adds `Filesystem::temporary()` to allow reading messages that may not fit in memory.
- Returned sockets are wrapped by their corresponding class in `innmind/io` to allow for a more declarative use
- Use `innmind/file-watch:~4.0`

## Note

The update of `innmind/file-watch` is not directly linked to the update of `innmind/amqp`. This update is here for consistency across the Innmind ecosystem by using the _continuation_ pattern everywhere possible. And since it's a BC break it's the right occasion to add this in a new major release.