### PR TITLE
Use `Attempt` to better explicit everywhere an action may fail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - `Innmind\OperatingSystem\Config::withHttpHeartbeat()` period is now expressed with a `Innmind\TimeContinuum\Period`
 - `Innmind\OperatingSystem\CurrentProcess::id()` now returns an `Innmind\Immutable\Attempt`
 - `Innmind\OperatingSystem\CurrentProcess::halt()` now returns `Innmind\Immutable\Attempt<Innmind\Immutable\SideEffect>`
+- `Innmind\OperatingSystem\Filesystem::mount()` now returns an `Innmind\Immutable\Attempt`
 - `Innmind\OperatingSystem\Filesystem::temporary()` now returns an `Innmind\Immutable\Attempt`
 - `Innmind\OperatingSystem\Ports::open()` now returns an `Innmind\Immutable\Attempt`
 - `Innmind\OperatingSystem\Remote::socket()` now returns an `Innmind\Immutable\Attempt`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@
 - Requires `innmind/immutable:~5.15`
 - `Innmind\OperatingSystem\Config::withHttpHeartbeat()` period is now expressed with a `Innmind\TimeContinuum\Period`
 - `Innmind\OperatingSystem\CurrentProcess::halt()` now returns `Innmind\Immutable\Attempt<Innmind\Immutable\SideEffect>`
+- `Innmind\OperatingSystem\Filesystem::temporary()` now returns an `Innmind\Immutable\Attempt`
+- `Innmind\OperatingSystem\Ports::open()` now returns an `Innmind\Immutable\Attempt`
+- `Innmind\OperatingSystem\Remote::socket()` now returns an `Innmind\Immutable\Attempt`
+- `Innmind\OperatingSystem\Sockets::open()` now returns an `Innmind\Immutable\Attempt`
+- `Innmind\OperatingSystem\Sockets::takeOver()` now returns an `Innmind\Immutable\Attempt`
+- `Innmind\OperatingSystem\Sockets::connectTo()` now returns an `Innmind\Immutable\Attempt`
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Requires `innmind/io:~3.2`
 - Requires `innmind/immutable:~5.15`
 - `Innmind\OperatingSystem\Config::withHttpHeartbeat()` period is now expressed with a `Innmind\TimeContinuum\Period`
+- `Innmind\OperatingSystem\CurrentProcess::id()` now returns an `Innmind\Immutable\Attempt`
 - `Innmind\OperatingSystem\CurrentProcess::halt()` now returns `Innmind\Immutable\Attempt<Innmind\Immutable\SideEffect>`
 - `Innmind\OperatingSystem\Filesystem::temporary()` now returns an `Innmind\Immutable\Attempt`
 - `Innmind\OperatingSystem\Ports::open()` now returns an `Innmind\Immutable\Attempt`

--- a/src/CurrentProcess.php
+++ b/src/CurrentProcess.php
@@ -14,7 +14,10 @@ use Innmind\Immutable\{
 
 interface CurrentProcess
 {
-    public function id(): Pid;
+    /**
+     * @return Attempt<Pid>
+     */
+    public function id(): Attempt;
     public function signals(): Signals;
 
     /**

--- a/src/CurrentProcess/Generic.php
+++ b/src/CurrentProcess/Generic.php
@@ -30,13 +30,15 @@ final class Generic implements CurrentProcess
     }
 
     #[\Override]
-    public function id(): Pid
+    public function id(): Attempt
     {
-        /**
-         * @psalm-suppress ArgumentTypeCoercion
-         * @psalm-suppress PossiblyFalseArgument
-         */
-        return new Pid(\getmypid());
+        $pid = \getmypid();
+
+        /** @psalm-suppress ArgumentTypeCoercion */
+        return match ($pid) {
+            false => Attempt::error(new \RuntimeException('Failed to retrieve process id')),
+            default => Attempt::result(new Pid($pid)),
+        };
     }
 
     #[\Override]

--- a/src/CurrentProcess/Logger.php
+++ b/src/CurrentProcess/Logger.php
@@ -4,7 +4,6 @@ declare(strict_types = 1);
 namespace Innmind\OperatingSystem\CurrentProcess;
 
 use Innmind\OperatingSystem\CurrentProcess;
-use Innmind\Server\Control\Server\Process\Pid;
 use Innmind\Server\Status\Server\Memory\Bytes;
 use Innmind\TimeContinuum\Period;
 use Innmind\Immutable\Attempt;
@@ -28,16 +27,16 @@ final class Logger implements CurrentProcess
     }
 
     #[\Override]
-    public function id(): Pid
+    public function id(): Attempt
     {
-        $pid = $this->process->id();
+        return $this->process->id()->map(function($pid) {
+            $this->logger->debug(
+                'Current process id is {pid}',
+                ['pid' => $pid->toInt()],
+            );
 
-        $this->logger->debug(
-            'Current process id is {pid}',
-            ['pid' => $pid->toInt()],
-        );
-
-        return $pid;
+            return $pid;
+        });
     }
 
     #[\Override]

--- a/src/Filesystem.php
+++ b/src/Filesystem.php
@@ -10,6 +10,7 @@ use Innmind\Filesystem\{
 use Innmind\Url\Path;
 use Innmind\FileWatch\Ping;
 use Innmind\Immutable\{
+    Attempt,
     Maybe,
     Str,
     Sequence,
@@ -36,7 +37,7 @@ interface Filesystem
      *
      * @param Sequence<Maybe<Str>> $chunks
      *
-     * @return Maybe<Content>
+     * @return Attempt<Content>
      */
-    public function temporary(Sequence $chunks): Maybe;
+    public function temporary(Sequence $chunks): Attempt;
 }

--- a/src/Filesystem.php
+++ b/src/Filesystem.php
@@ -18,7 +18,10 @@ use Innmind\Immutable\{
 
 interface Filesystem
 {
-    public function mount(Path $path): Adapter;
+    /**
+     * @return Attempt<Adapter>
+     */
+    public function mount(Path $path): Attempt;
     public function contains(Path $path): bool;
 
     /**

--- a/src/Filesystem/Generic.php
+++ b/src/Filesystem/Generic.php
@@ -48,7 +48,7 @@ final class Generic implements Filesystem
     }
 
     #[\Override]
-    public function mount(Path $path): Adapter
+    public function mount(Path $path): Attempt
     {
         /**
          * @var Adapter $adapter
@@ -56,20 +56,22 @@ final class Generic implements Filesystem
          */
         foreach ($this->mounted as $adapter => $mounted) {
             if ($path->toString() === $mounted) {
-                return $adapter;
+                return Attempt::result($adapter);
             }
         }
 
-        $adapter = Adapter\Filesystem::mount(
-            $path,
-            $this->config->io(),
-        )
-            ->withCaseSensitivity(
-                $this->config->filesystemCaseSensitivity(),
-            );
-        $this->mounted[$adapter] = $path->toString();
+        return Attempt::of(function() use ($path) {
+            $adapter = Adapter\Filesystem::mount(
+                $path,
+                $this->config->io(),
+            )
+                ->withCaseSensitivity(
+                    $this->config->filesystemCaseSensitivity(),
+                );
+            $this->mounted[$adapter] = $path->toString();
 
-        return $adapter;
+            return $adapter;
+        });
     }
 
     #[\Override]

--- a/src/Filesystem/Generic.php
+++ b/src/Filesystem/Generic.php
@@ -111,7 +111,7 @@ final class Generic implements Filesystem
     }
 
     #[\Override]
-    public function temporary(Sequence $chunks): Maybe
+    public function temporary(Sequence $chunks): Attempt
     {
         return Attempt::of(
             fn() => $this
@@ -129,6 +129,6 @@ final class Generic implements Filesystem
                 ->map(static fn($tmp) => $tmp->read())
                 ->map(Content::io(...))
                 ->unwrap(),
-        )->maybe();
+        );
     }
 }

--- a/src/Filesystem/Logger.php
+++ b/src/Filesystem/Logger.php
@@ -11,6 +11,7 @@ use Innmind\Filesystem\{
 use Innmind\Url\Path;
 use Innmind\FileWatch\Ping;
 use Innmind\Immutable\{
+    Attempt,
     Maybe,
     Sequence,
 };
@@ -82,7 +83,7 @@ final class Logger implements Filesystem
     }
 
     #[\Override]
-    public function temporary(Sequence $chunks): Maybe
+    public function temporary(Sequence $chunks): Attempt
     {
         return $this
             ->filesystem

--- a/src/Filesystem/Logger.php
+++ b/src/Filesystem/Logger.php
@@ -38,11 +38,13 @@ final class Logger implements Filesystem
     }
 
     #[\Override]
-    public function mount(Path $path): Adapter
+    public function mount(Path $path): Attempt
     {
-        return Adapter\Logger::psr(
-            $this->filesystem->mount($path),
-            $this->logger,
+        return $this->filesystem->mount($path)->map(
+            fn($adapter) => Adapter\Logger::psr(
+                $adapter,
+                $this->logger,
+            ),
         );
     }
 

--- a/src/Ports.php
+++ b/src/Ports.php
@@ -9,12 +9,12 @@ use Innmind\IO\{
     Sockets\Internet\Transport,
 };
 use Innmind\IP\IP;
-use Innmind\Immutable\Maybe;
+use Innmind\Immutable\Attempt;
 
 interface Ports
 {
     /**
-     * @return Maybe<Server>
+     * @return Attempt<Server>
      */
-    public function open(Transport $transport, IP $ip, Port $port): Maybe;
+    public function open(Transport $transport, IP $ip, Port $port): Attempt;
 }

--- a/src/Ports/Logger.php
+++ b/src/Ports/Logger.php
@@ -7,7 +7,7 @@ use Innmind\OperatingSystem\Ports;
 use Innmind\Url\Authority\Port;
 use Innmind\IO\Sockets\Internet\Transport;
 use Innmind\IP\IP;
-use Innmind\Immutable\Maybe;
+use Innmind\Immutable\Attempt;
 use Psr\Log\LoggerInterface;
 
 final class Logger implements Ports
@@ -27,7 +27,7 @@ final class Logger implements Ports
     }
 
     #[\Override]
-    public function open(Transport $transport, IP $ip, Port $port): Maybe
+    public function open(Transport $transport, IP $ip, Port $port): Attempt
     {
         $this->logger->debug(
             'Opening new port at {address}',

--- a/src/Ports/Unix.php
+++ b/src/Ports/Unix.php
@@ -10,7 +10,7 @@ use Innmind\OperatingSystem\{
 use Innmind\Url\Authority\Port;
 use Innmind\IO\Sockets\Internet\Transport;
 use Innmind\IP\IP;
-use Innmind\Immutable\Maybe;
+use Innmind\Immutable\Attempt;
 
 final class Unix implements Ports
 {
@@ -30,14 +30,13 @@ final class Unix implements Ports
     }
 
     #[\Override]
-    public function open(Transport $transport, IP $ip, Port $port): Maybe
+    public function open(Transport $transport, IP $ip, Port $port): Attempt
     {
         return $this
             ->config
             ->io()
             ->sockets()
             ->servers()
-            ->internet($transport, $ip, $port)
-            ->maybe();
+            ->internet($transport, $ip, $port);
     }
 }

--- a/src/Remote.php
+++ b/src/Remote.php
@@ -13,7 +13,7 @@ use Innmind\Url\{
     Authority,
 };
 use Innmind\HttpTransport\Transport as HttpTransport;
-use Innmind\Immutable\Maybe;
+use Innmind\Immutable\Attempt;
 use Formal\AccessLayer\Connection;
 
 interface Remote
@@ -21,9 +21,9 @@ interface Remote
     public function ssh(Url $server): Server;
 
     /**
-     * @return Maybe<Client>
+     * @return Attempt<Client>
      */
-    public function socket(Transport $transport, Authority $authority): Maybe;
+    public function socket(Transport $transport, Authority $authority): Attempt;
     public function http(): HttpTransport;
     public function sql(Url $server): Connection;
 }

--- a/src/Remote/Generic.php
+++ b/src/Remote/Generic.php
@@ -21,7 +21,7 @@ use Innmind\HttpTransport\{
     Transport as HttpTransport,
     Curl,
 };
-use Innmind\Immutable\Maybe;
+use Innmind\Immutable\Attempt;
 use Formal\AccessLayer\Connection;
 
 final class Generic implements Remote
@@ -62,15 +62,14 @@ final class Generic implements Remote
     }
 
     #[\Override]
-    public function socket(Transport $transport, Authority $authority): Maybe
+    public function socket(Transport $transport, Authority $authority): Attempt
     {
         return $this
             ->config
             ->io()
             ->sockets()
             ->clients()
-            ->internet($transport, $authority)
-            ->maybe();
+            ->internet($transport, $authority);
     }
 
     #[\Override]

--- a/src/Remote/Logger.php
+++ b/src/Remote/Logger.php
@@ -11,7 +11,7 @@ use Innmind\Url\{
     Authority,
 };
 use Innmind\HttpTransport;
-use Innmind\Immutable\Maybe;
+use Innmind\Immutable\Attempt;
 use Formal\AccessLayer\Connection;
 use Psr\Log\LoggerInterface;
 
@@ -41,7 +41,7 @@ final class Logger implements Remote
     }
 
     #[\Override]
-    public function socket(Transport $transport, Authority $authority): Maybe
+    public function socket(Transport $transport, Authority $authority): Attempt
     {
         $this->logger->debug(
             'Opening remote socket at {address}',

--- a/src/Remote/Resilient.php
+++ b/src/Remote/Resilient.php
@@ -19,10 +19,7 @@ use Innmind\HttpTransport\{
     Transport as HttpTransport,
     ExponentialBackoff,
 };
-use Innmind\Immutable\{
-    Maybe,
-    Attempt,
-};
+use Innmind\Immutable\Attempt;
 use Formal\AccessLayer\Connection;
 
 final class Resilient implements Remote
@@ -48,7 +45,7 @@ final class Resilient implements Remote
     }
 
     #[\Override]
-    public function socket(Transport $transport, Authority $authority): Maybe
+    public function socket(Transport $transport, Authority $authority): Attempt
     {
         return $this->remote->socket($transport, $authority);
     }

--- a/src/Sockets.php
+++ b/src/Sockets.php
@@ -8,26 +8,26 @@ use Innmind\IO\{
     Sockets\Servers\Server,
     Sockets\Unix\Address,
 };
-use Innmind\Immutable\Maybe;
+use Innmind\Immutable\Attempt;
 
 interface Sockets
 {
     /**
      * This method will fail if the socket already exist
      *
-     * @return Maybe<Server>
+     * @return Attempt<Server>
      */
-    public function open(Address $address): Maybe;
+    public function open(Address $address): Attempt;
 
     /**
      * This will take control of the socket if it already exist (use carefully)
      *
-     * @return Maybe<Server>
+     * @return Attempt<Server>
      */
-    public function takeOver(Address $address): Maybe;
+    public function takeOver(Address $address): Attempt;
 
     /**
-     * @return Maybe<Client>
+     * @return Attempt<Client>
      */
-    public function connectTo(Address $address): Maybe;
+    public function connectTo(Address $address): Attempt;
 }

--- a/src/Sockets/Logger.php
+++ b/src/Sockets/Logger.php
@@ -5,7 +5,7 @@ namespace Innmind\OperatingSystem\Sockets;
 
 use Innmind\OperatingSystem\Sockets;
 use Innmind\IO\Sockets\Unix\Address;
-use Innmind\Immutable\Maybe;
+use Innmind\Immutable\Attempt;
 use Psr\Log\LoggerInterface;
 
 final class Logger implements Sockets
@@ -25,7 +25,7 @@ final class Logger implements Sockets
     }
 
     #[\Override]
-    public function open(Address $address): Maybe
+    public function open(Address $address): Attempt
     {
         $this->logger->debug(
             'Opening socket at {address}',
@@ -36,7 +36,7 @@ final class Logger implements Sockets
     }
 
     #[\Override]
-    public function takeOver(Address $address): Maybe
+    public function takeOver(Address $address): Attempt
     {
         $this->logger->debug(
             'Taking over the socket at {address}',
@@ -47,7 +47,7 @@ final class Logger implements Sockets
     }
 
     #[\Override]
-    public function connectTo(Address $address): Maybe
+    public function connectTo(Address $address): Attempt
     {
         $this->logger->debug(
             'Connecting to socket at {address}',

--- a/src/Sockets/Unix.php
+++ b/src/Sockets/Unix.php
@@ -8,7 +8,7 @@ use Innmind\OperatingSystem\{
     Config,
 };
 use Innmind\IO\Sockets\Unix\Address;
-use Innmind\Immutable\Maybe;
+use Innmind\Immutable\Attempt;
 
 final class Unix implements Sockets
 {
@@ -28,38 +28,35 @@ final class Unix implements Sockets
     }
 
     #[\Override]
-    public function open(Address $address): Maybe
+    public function open(Address $address): Attempt
     {
         return $this
             ->config
             ->io()
             ->sockets()
             ->servers()
-            ->unix($address)
-            ->maybe();
+            ->unix($address);
     }
 
     #[\Override]
-    public function takeOver(Address $address): Maybe
+    public function takeOver(Address $address): Attempt
     {
         return $this
             ->config
             ->io()
             ->sockets()
             ->servers()
-            ->takeOver($address)
-            ->maybe();
+            ->takeOver($address);
     }
 
     #[\Override]
-    public function connectTo(Address $address): Maybe
+    public function connectTo(Address $address): Attempt
     {
         return $this
             ->config
             ->io()
             ->sockets()
             ->clients()
-            ->unix($address)
-            ->maybe();
+            ->unix($address);
     }
 }

--- a/tests/CurrentProcess/GenericTest.php
+++ b/tests/CurrentProcess/GenericTest.php
@@ -29,8 +29,11 @@ class GenericTest extends TestCase
     {
         $process = Generic::of($this->createMock(Halt::class));
 
-        $this->assertInstanceOf(Pid::class, $process->id());
-        $this->assertSame($process->id()->toInt(), $process->id()->toInt());
+        $this->assertInstanceOf(Pid::class, $process->id()->unwrap());
+        $this->assertSame(
+            $process->id()->unwrap()->toInt(),
+            $process->id()->unwrap()->toInt(),
+        );
     }
 
     public function testHalt()

--- a/tests/CurrentProcess/LoggerTest.php
+++ b/tests/CurrentProcess/LoggerTest.php
@@ -46,7 +46,7 @@ class LoggerTest extends TestCase
                 $inner
                     ->expects($this->once())
                     ->method('id')
-                    ->willReturn($expected = new Pid($id));
+                    ->willReturn(Attempt::result($expected = new Pid($id)));
                 $logger = $this->createMock(LoggerInterface::class);
                 $logger
                     ->expects($this->once())
@@ -57,7 +57,7 @@ class LoggerTest extends TestCase
                     );
                 $process = Logger::psr($inner, $logger);
 
-                $this->assertSame($expected, $process->id());
+                $this->assertSame($expected, $process->id()->unwrap());
             });
     }
 

--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -49,7 +49,8 @@ class FactoryTest extends TestCase
         $os = Factory::build(Config::of()->caseInsensitiveFilesystem());
         $adapter = $os
             ->filesystem()
-            ->mount(Path::of($path));
+            ->mount(Path::of($path))
+            ->unwrap();
         $adapter->add(
             $directory = Directory::named('0')
                 ->add($file = File::named('L', Content::none()))

--- a/tests/Filesystem/GenericTest.php
+++ b/tests/Filesystem/GenericTest.php
@@ -49,7 +49,7 @@ class GenericTest extends TestCase
             Config::of(),
         );
 
-        $adapter = $filesystem->mount(Path::of('/tmp/'));
+        $adapter = $filesystem->mount(Path::of('/tmp/'))->unwrap();
 
         $this->assertInstanceOf(FilesystemAdapter::class, $adapter);
     }
@@ -61,9 +61,9 @@ class GenericTest extends TestCase
             Config::of(),
         );
 
-        $adapter = $filesystem->mount(Path::of('/tmp/'));
+        $adapter = $filesystem->mount(Path::of('/tmp/'))->unwrap();
 
-        $this->assertSame($adapter, $filesystem->mount(Path::of('/tmp/')));
+        $this->assertSame($adapter, $filesystem->mount(Path::of('/tmp/'))->unwrap());
     }
 
     public function testContainsFile()

--- a/tests/Filesystem/LoggerTest.php
+++ b/tests/Filesystem/LoggerTest.php
@@ -14,7 +14,10 @@ use Innmind\{
     FileWatch\Ping,
 };
 use Innmind\TimeWarp\Halt;
-use Innmind\Immutable\Maybe;
+use Innmind\Immutable\{
+    Attempt,
+    Maybe,
+};
 use Psr\Log\LoggerInterface;
 use PHPUnit\Framework\TestCase;
 use Innmind\BlackBox\{
@@ -47,11 +50,15 @@ class LoggerTest extends TestCase
                 $inner
                     ->expects($this->once())
                     ->method('mount')
-                    ->with($path);
+                    ->with($path)
+                    ->willReturn(Attempt::result($this->createMock(Adapter::class)));
                 $logger = $this->createMock(LoggerInterface::class);
                 $filesystem = Logger::psr($inner, $logger);
 
-                $this->assertInstanceOf(Adapter\Logger::class, $filesystem->mount($path));
+                $this->assertInstanceOf(
+                    Adapter\Logger::class,
+                    $filesystem->mount($path)->unwrap(),
+                );
             });
     }
 

--- a/tests/Ports/LoggerTest.php
+++ b/tests/Ports/LoggerTest.php
@@ -16,7 +16,7 @@ use Innmind\IP\{
     IPv4,
     IPv6,
 };
-use Innmind\Immutable\Maybe;
+use Innmind\Immutable\Attempt;
 use Psr\Log\LoggerInterface;
 use PHPUnit\Framework\TestCase;
 use Innmind\BlackBox\{
@@ -63,7 +63,7 @@ class LoggerTest extends TestCase
                     ->expects($this->once())
                     ->method('open')
                     ->with($transport, $ip, Port::of($port))
-                    ->willReturn($expected = Maybe::just(null /* hack to avoid creating real server */));
+                    ->willReturn($expected = Attempt::result(null /* hack to avoid creating real server */));
                 $logger = $this->createMock(LoggerInterface::class);
                 $logger
                     ->expects($this->once())

--- a/tests/Remote/LoggerTest.php
+++ b/tests/Remote/LoggerTest.php
@@ -14,7 +14,7 @@ use Innmind\IO\Sockets\{
     Clients\Client,
 };
 use Innmind\Url\Url;
-use Innmind\Immutable\Maybe;
+use Innmind\Immutable\Attempt;
 use Formal\AccessLayer\Connection;
 use Psr\Log\LoggerInterface;
 use PHPUnit\Framework\TestCase;
@@ -82,7 +82,7 @@ class LoggerTest extends TestCase
                     ->expects($this->once())
                     ->method('socket')
                     ->with($transport, $authority)
-                    ->willReturn($expected = Maybe::just(null /* hack to avoid creating real client */));
+                    ->willReturn($expected = Attempt::result(null /* hack to avoid creating real client */));
                 $logger = $this->createMock(LoggerInterface::class);
                 $logger
                     ->expects($this->once())

--- a/tests/Remote/ResilientTest.php
+++ b/tests/Remote/ResilientTest.php
@@ -14,7 +14,7 @@ use Innmind\IO\Sockets\{
     Internet\Transport,
     Clients\Client,
 };
-use Innmind\Immutable\Maybe;
+use Innmind\Immutable\Attempt;
 use Formal\AccessLayer\Connection;
 use PHPUnit\Framework\TestCase;
 use Innmind\BlackBox\{
@@ -82,7 +82,7 @@ class ResilientTest extends TestCase
                     ->expects($this->once())
                     ->method('socket')
                     ->with($transport, $authority)
-                    ->willReturn($expected = Maybe::just(null /* hack to avoid creating real client */));
+                    ->willReturn($expected = Attempt::result(null /* hack to avoid creating real client */));
 
                 $this->assertSame($expected, $remote->socket($transport, $authority));
             });

--- a/tests/Sockets/LoggerTest.php
+++ b/tests/Sockets/LoggerTest.php
@@ -13,7 +13,7 @@ use Innmind\IO\Sockets\{
     Clients\Client,
 };
 use Innmind\Url\Path;
-use Innmind\Immutable\Maybe;
+use Innmind\Immutable\Attempt;
 use Psr\Log\LoggerInterface;
 use PHPUnit\Framework\TestCase;
 
@@ -38,7 +38,7 @@ class LoggerTest extends TestCase
             ->expects($this->once())
             ->method('open')
             ->with($address)
-            ->willReturn($expected = Maybe::just(null /* hack to avoid creating real server */));
+            ->willReturn($expected = Attempt::result(null /* hack to avoid creating real server */));
         $logger = $this->createMock(LoggerInterface::class);
         $logger
             ->expects($this->once())
@@ -60,7 +60,7 @@ class LoggerTest extends TestCase
             ->expects($this->once())
             ->method('takeOver')
             ->with($address)
-            ->willReturn($expected = Maybe::just(null /* hack to avoid creating real server */));
+            ->willReturn($expected = Attempt::result(null /* hack to avoid creating real server */));
         $logger = $this->createMock(LoggerInterface::class);
         $logger
             ->expects($this->once())
@@ -82,7 +82,7 @@ class LoggerTest extends TestCase
             ->expects($this->once())
             ->method('connectTo')
             ->with($address)
-            ->willReturn($expected = Maybe::just(null /* hack to avoid creating real client */));
+            ->willReturn($expected = Attempt::result(null /* hack to avoid creating real client */));
         $logger = $this->createMock(LoggerInterface::class);
         $logger
             ->expects($this->once())


### PR DESCRIPTION
Regarding the `Filesystem::mount()` change, it can fail when the path points to a network partition.