### PR TITLE
Use `Attempt<Str>` as source of temporary files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@
 - `Innmind\OperatingSystem\CurrentProcess` is now a final class
 - `Innmind\OperatingSystem\OperatingSystem::map()` callable must now return a `Config`
 - `Innmind\OperatingSystem\Config::of()` has been renamed `::new()`
+- `Innmind\OperatingSystem\Filesystem::temporary()` now expects a `Innmind\Immutable\Sequence<Innmind\Immutable\Attempt<Innmind\Immutable\Str>>`
 
 ### Fixed
 

--- a/src/Filesystem.php
+++ b/src/Filesystem.php
@@ -117,7 +117,7 @@ final class Filesystem
      * can't be read twice. By using this temporary file content you can read it
      * multiple times.
      *
-     * @param Sequence<Maybe<Str>> $chunks
+     * @param Sequence<Attempt<Str>> $chunks
      *
      * @return Attempt<Content>
      */
@@ -133,7 +133,6 @@ final class Filesystem
                     ->sink($tmp->push()->chunk(...))
                     ->attempt(
                         static fn($push, $chunk) => $chunk
-                            ->attempt(static fn() => new \RuntimeException('Failed to load chunk'))
                             ->flatMap($push)
                             ->map(static fn() => $push),
                     )

--- a/tests/FilesystemTest.php
+++ b/tests/FilesystemTest.php
@@ -19,6 +19,7 @@ use Innmind\Immutable\{
     Sequence,
     Str,
     Maybe,
+    Attempt,
 };
 use Innmind\BlackBox\{
     PHPUnit\BlackBox,
@@ -134,7 +135,7 @@ class FilesystemTest extends TestCase
                     ->temporary(
                         Sequence::of(...$chunks)
                             ->map(Str::of(...))
-                            ->map(Maybe::just(...)),
+                            ->map(Attempt::result(...)),
                     )
                     ->match(
                         static fn($content) => $content,
@@ -166,6 +167,9 @@ class FilesystemTest extends TestCase
                     ->temporary(
                         Sequence::of(...[...$leading, null, ...$trailing])
                             ->map(Maybe::of(...))
+                            ->map(static fn($chunk) => $chunk->attempt(
+                                static fn() => new \RuntimeException,
+                            ))
                             ->map(static fn($chunk) => $chunk->map(Str::of(...))),
                     )
                     ->match(


### PR DESCRIPTION
This method is mainly used in `innmind/amqp` to create files coming from the socket. The type returned from the socket should be an `Attempt<Str>` hence the change.

And if someone still use `Maybe`s they can call `->attempt()` on it to make it compatible.